### PR TITLE
Minor patch for MongoDB typo

### DIFF
--- a/R/wildobs_mongo_query.R
+++ b/R/wildobs_mongo_query.R
@@ -178,6 +178,12 @@ wildobs_mongo_query = function(db_url = NULL, api_key = NULL,
       } # end else admin api key check
     } # end use api
 
+  ## quick band-aid, IDK how this got in the DB but an Issue has been created on camDB GitHub
+  ## COME HERE AND DELETE WHEN FIXED!
+  if(any(grepl("pending development of collaborative research agreement", metadata$WildObsMetadata$tabularSharingPreference))){
+    metadata$WildObsMetadata$tabularSharingPreference[which(grepl("pending development of collaborative research agreement", metadata$WildObsMetadata$tabularSharingPreference))] = "closed"
+  }
+
   ## and immediately thin metadata to include the specific sharing preferences
   metadata = metadata[metadata$WildObsMetadata$tabularSharingPreference %in% tabularSharingPreference, ]
 


### PR DESCRIPTION
This is related to an [issue in camDB](https://github.com/WildObs/cam-DB/issues/221) that allowed a non-enumerated value into Mongo. This simply corrects this specific typo back into an enumerated value. 